### PR TITLE
add payment-information-mixin compatibility with magento > 2.3.3

### DIFF
--- a/view/frontend/requirejs-config.js
+++ b/view/frontend/requirejs-config.js
@@ -11,8 +11,8 @@ var config = {
             'Magento_Checkout/js/action/place-order': {
                 'Hevelop_InvoiceRequest/js/place-order-mixin': true
             },
-            'Magento_Checkout/js/action/set-payment-information': {
-                'Hevelop_InvoiceRequest/js/set-payment-information-mixin': true
+            'Magento_Checkout/js/action/set-payment-information-extended': {
+                'Hevelop_InvoiceRequest/js/set-payment-information-extended-mixin': true
             }
         }
     }

--- a/view/frontend/web/js/set-payment-information-extended-mixin.js
+++ b/view/frontend/web/js/set-payment-information-extended-mixin.js
@@ -11,8 +11,8 @@ define([
 ], function (wrapper, saveBillingAction) {
     'use strict';
 
-    return function (setPaymentInformationAction) {
-        return wrapper.wrap(setPaymentInformationAction, function (originalAction) {
+    return function (setPaymentInformationExtendedAction) {
+        return wrapper.wrap(setPaymentInformationExtendedAction, function (originalAction) {
             saveBillingAction();
             return originalAction();
         });


### PR DESCRIPTION
I fixed a compatibility issue with magento greater than 2.3.3, but it is not backwards compatible